### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/leetomy/25b2d006-6ecb-47e3-bd55-842025b08dad/3aa020fe-d90a-4ff2-a833-13c83e35a7d6/_apis/work/boardbadge/b46c4872-1823-444c-9f9b-02f417635fcc)](https://dev.azure.com/leetomy/25b2d006-6ecb-47e3-bd55-842025b08dad/_boards/board/t/3aa020fe-d90a-4ff2-a833-13c83e35a7d6/Microsoft.RequirementCategory)
 # Create React App [![Build Status](https://dev.azure.com/facebook/create-react-app/_apis/build/status/facebook.create-react-app?branchName=main)](https://dev.azure.com/facebook/create-react-app/_build/latest?definitionId=1&branchName=main) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)](https://github.com/facebook/create-react-app/blob/main/CONTRIBUTING.md)
 
 <img alt="Logo" align="right" src="https://create-react-app.dev/img/logo.svg" width="20%" />


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/leetomy/25b2d006-6ecb-47e3-bd55-842025b08dad/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.